### PR TITLE
Fixed error in search param code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ ImplementationGuide-mii-ig-medikation*
 fsh-index.json
 fsh-index.txt
 MII_CS_IHE_XDS_Fallkontext_bei_Dokumentenerstellung.json
+index.html

--- a/fsh-generated/resources/SearchParameter-mii-sp-medikation-medicationadministration-dose.json
+++ b/fsh-generated/resources/SearchParameter-mii-sp-medikation-medicationadministration-dose.json
@@ -17,9 +17,9 @@
   "name": "MII_SP_Medikation_MedicationAdministration_Dose",
   "status": "active",
   "experimental": false,
-  "date": "2022-06-28",
+  "date": "2024-06-24",
   "description": "Suchparameter für MedicationAdministration.dosage.dose",
-  "code": "ratequantity",
+  "code": "dose",
   "base": [
     "MedicationAdministration"
   ],

--- a/implementation-guides/mii-ig-medikation-de-v2024/MIIIGModulMedikation/TechnischeImplementierung/FHIR-Profile/MedicationAdministration.page.md
+++ b/implementation-guides/mii-ig-medikation-de-v2024/MIIIGModulMedikation/TechnischeImplementierung/FHIR-Profile/MedicationAdministration.page.md
@@ -157,13 +157,13 @@ Folgende Suchparameter sind für das Modul Medikation relevant, auch in Kombinat
     
     Anwendungshinweise: Weitere Informationen zur Suche nach "dosage-route" finden sich in der [FHIR-Basisspezifikation - Abschnitt "token"](http://hl7.org/fhir/R4/search.html#token).
 
-12. Der Suchparameter "ratequantity" MUSS unterstützt werden:
+12. Der Suchparameter "dose" MUSS unterstützt werden:
 
     Beispiele:
 
-    ```GET [base]/MedicationAdministration?ratequantity=100|http://unitsofmeasure.org|mg```
+    ```GET [base]/MedicationAdministration?dose=100|http://unitsofmeasure.org|mg```
     
-    Anwendungshinweise: Weitere Informationen zur Suche nach "ratequantity" finden sich in der [FHIR-Basisspezifikation - Abschnitt "quantity"](https://hl7.org/fhir/search.html#quantity).
+    Anwendungshinweise: Weitere Informationen zur Suche nach "dose" finden sich in der [FHIR-Basisspezifikation - Abschnitt "quantity"](https://hl7.org/fhir/search.html#quantity).
 
 13. Der Suchparameter "rateratio-numerator" MUSS unterstützt werden:
 
@@ -173,7 +173,7 @@ Folgende Suchparameter sind für das Modul Medikation relevant, auch in Kombinat
     
     Anwendungshinweise: Weitere Informationen zur Suche nach "rateratio-numerator" finden sich in der [FHIR-Basisspezifikation - Abschnitt "quantity"](https://hl7.org/fhir/search.html#quantity).
 
-14. Der Suchparameter "rateratio-numerator" MUSS unterstützt werden:
+14. Der Suchparameter "rateratio-denominator" MUSS unterstützt werden:
 
     Beispiele:
 
@@ -188,6 +188,14 @@ Folgende Suchparameter sind für das Modul Medikation relevant, auch in Kombinat
     ```GET [base]/MedicationAdministration?rateratio=250|http://unitsofmeasure.org|mL$1|http://unitsofmeasure.org|h```
     
     Anwendungshinweise: Weitere Informationen zur Suche nach "rateratio" finden sich in der [FHIR-Basisspezifikation - Abschnitt "composite"](http://hl7.org/fhir/search.html#composite).
+
+16. Der Suchparameter "ratequantity" MUSS unterstützt werden:
+
+    Beispiele:
+
+    ```GET [base]/MedicationAdministration?ratequantity=100|http://unitsofmeasure.org|mg/h```
+    
+    Anwendungshinweise: Weitere Informationen zur Suche nach "ratequantity" finden sich in der [FHIR-Basisspezifikation - Abschnitt "quantity"](https://hl7.org/fhir/search.html#quantity).
 
 ---
 

--- a/input/fsh/searchparameters/SearchParameter.fsh
+++ b/input/fsh/searchparameters/SearchParameter.fsh
@@ -361,9 +361,9 @@ Usage: #definition
 * name = "MII_SP_Medikation_MedicationAdministration_Dose"
 * status = #active
 * experimental = false
-* date = "2022-06-28"
+* date = "2024-06-24"
 * description = "Suchparameter für MedicationAdministration.dosage.dose"
-* code = #ratequantity
+* code = #dose
 * base[+] = #MedicationAdministration
 * type = #quantity
 * expression = "MedicationAdministration.dosage.dose"

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -16,3 +16,5 @@ dependencies:
   hl7.fhir.uv.ips: 1.0.0
   de.medizininformatikinitiative.kerndatensatz.meta: 1.0.3
   de.ihe-d.terminology: 3.0.0
+menu:
+  Home: index.html


### PR DESCRIPTION
Suchparameter für MedicationAdministration.dosage.dose code: 'ratequantity' fehlerhaft, muss 'dose' sein